### PR TITLE
ci: use token generated by github app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,16 @@ jobs:
   create-the-release-pull-request-and-release:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub Apps token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
       - uses: google-github-actions/release-please-action@v3
         id: release
         with:
+          token: ${{ steps.generate_token.outputs.token }}
           release-type: python
           package-name: depwatch
           bump-minor-pre-major: true


### PR DESCRIPTION
Fixed an issue where GitHub Actions were not triggered by PR creation with the Release Please GitHub App.

- cf. https://github.com/peter-evans/create-pull-request/issues/48